### PR TITLE
[HOTFIX] ssl secret name

### DIFF
--- a/hm-basic-webapp/Chart.yaml
+++ b/hm-basic-webapp/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/hm-basic-webapp/templates/ingress.yaml
+++ b/hm-basic-webapp/templates/ingress.yaml
@@ -7,9 +7,15 @@ metadata:
 spec:
   tls:
     {{- range $item := .Values.ssl }}
-    - secretName: "{{ $item.name }}-tls"
-      hosts:
-        - {{ $item.host }}
+      {{- if (eq $item.manual true) }}
+      - secretName: "{{ $item.name }}"
+        hosts:
+          - {{ $item.host }}
+      {{ else }}
+      - secretName: "{{ $item.name }}-tls"
+        hosts:
+          - {{ $item.host }}
+      {{ end }}
     {{- end }}
   rules:
     {{- $prefix := include "hm-basic-webapp.prefix" . }}


### PR DESCRIPTION
Fix ssl secretName when ssl setting set to manual

if manual is set to `false` it’s taken care by https://github.com/highmobility/helm-charts/blob/main/hm-basic-webapp/templates/certificates.yaml

that’s why it needs extra `tls`. If manual is set to `true`, the user of this helm can set any value. this is used to reuse the existing secrets