### PR TITLE
Make tls secret name explicit

### DIFF
--- a/hm-basic-webapp/templates/certificates.yaml
+++ b/hm-basic-webapp/templates/certificates.yaml
@@ -6,9 +6,9 @@
 apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
-  name: "{{ $environment }}-{{ $item.name }}-cert"
+  name: "{{ $environment }}-{{ $item.host | replace "." "-" }}-cert"
 spec:
-  secretName: "{{ $item.name }}-tls"
+  secretName: "{{ $item.tlsSecretName }}"
   renewBefore: 360h # 15d
   commonName: {{ $item.host }}
   dnsNames:

--- a/hm-basic-webapp/templates/ingress.yaml
+++ b/hm-basic-webapp/templates/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   tls:
     {{- range $item := .Values.ssl }}
-    - secretName: "{{ $item.name }}-tls"
+    - secretName: "{{ $item.tlsSecretName }}"
       hosts:
         - {{ $item.host }}
     {{- end }}


### PR DESCRIPTION
in order to support both manual and automatic(letencrypt) we decided to make the tls explicit and have to be past fully by the client of this library