### PR TITLE
simplify the ingress config

### DIFF
--- a/hm-basic-webapp/Chart.yaml
+++ b/hm-basic-webapp/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 2.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/hm-basic-webapp/templates/certificates.yaml
+++ b/hm-basic-webapp/templates/certificates.yaml
@@ -1,24 +1,22 @@
-{{- if .Values.ssl }}
-{{- if (eq .Values.ssl.enabled true) }}
+{{- if .Values.ingress }}
+{{- if (eq .Values.ingress.enabled true) }}
 {{- $environment := .Values.environmentName -}}
 {{- $lets_encrypt_name := include "hm-basic-webapp.letsEncryptProductionName" . }}
-{{- range $item := .Values.ssl }}
-{{- if eq $item.manual false }}
+{{- if eq .Values.ingress.acme true }}
 ---
 apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
-  name: "{{ $environment }}-{{ $item.host | replace "." "-" }}-cert"
+  name: "{{ $environment }}-{{ .Values.hostname | replace "." "-" }}-cert"
 spec:
-  secretName: "{{ $item.tlsSecretName }}"
+  secretName: "{{ .Values.ingress.tlsSecretName }}"
   renewBefore: 360h # 15d
-  commonName: {{ $item.host }}
+  commonName: {{ .Values.hostname }}
   dnsNames:
-    - {{ $item.host }}
+    - {{ .Values.hostname }}
   issuerRef:
     name: {{ $lets_encrypt_name }}
     kind: Issuer
-{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/hm-basic-webapp/templates/ingress.yaml
+++ b/hm-basic-webapp/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- if (eq .Values.ingress.enabled true) }}
 {{- $fullName := include "hm-basic-webapp.prefix" . }}
 {{- $servicePort := .Values.servicePort -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "hm-basic-webapp.prefix" . }}
@@ -22,7 +22,9 @@ spec:
         paths:
           - path: {{ .Values.ingress.path }}
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $servicePort }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $servicePort }}
 {{- end }}
 {{- end }}

--- a/hm-basic-webapp/templates/ingress.yaml
+++ b/hm-basic-webapp/templates/ingress.yaml
@@ -1,5 +1,7 @@
 {{- if .Values.ingress }}
 {{- if (eq .Values.ingress.enabled true) }}
+{{- $fullName := include "hm-basic-webapp.prefix" . }}
+{{- $servicePort := .Values.servicePort -}}
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
@@ -7,23 +9,20 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: nginx
 spec:
+  {{- if .Values.ingress.tlsSecretName }}
   tls:
-    {{- range $item := .Values.ssl }}
-    - secretName: "{{ $item.tlsSecretName }}"
-      hosts:
-        - {{ $item.host }}
-    {{- end }}
+    - hosts:
+        - {{ .Values.hostname | quote }}
+      secretName: {{ .Values.ingress.tlsSecretName }}
+  {{- end }}
+
   rules:
-    {{- $prefix := include "hm-basic-webapp.prefix" . }}
-    {{- $servicePort := .Values.servicePort -}}
-    {{- range $item := .Values.ssl }}
-    - host: {{ $item.host }}
+    - host: {{ .Values.hostname | quote }}
       http:
         paths:
-          - path: {{ $item.path }}
+          - path: {{ .Values.ingress.path }}
             backend:
-              serviceName: {{ $prefix }}
+              serviceName: {{ $fullName }}
               servicePort: {{ $servicePort }}
-    {{- end }}
 {{- end }}
 {{- end }}

--- a/hm-basic-webapp/templates/lets_encrypt_production.yaml
+++ b/hm-basic-webapp/templates/lets_encrypt_production.yaml
@@ -1,6 +1,5 @@
-{{- if .Values.ssl }}
-{{- if (eq .Values.ssl.enabled true) }}
-{{- if not (eq .Values.environmentName "prod") }}
+{{- if .Values.ingress }}
+{{- if and .Values.ingress.enabled .Values.ingress.acme  }}
 apiVersion: cert-manager.io/v1alpha2
 kind: Issuer
 metadata:
@@ -19,6 +18,5 @@ spec:
    - http01:
        ingress:
          class: nginx
-{{- end }}
 {{- end }}
 {{- end }}

--- a/hm-basic-webapp/templates/lets_encrypt_staging.yaml
+++ b/hm-basic-webapp/templates/lets_encrypt_staging.yaml
@@ -1,5 +1,5 @@
-{{- if .Values.ssl }}
-{{- if (eq .Values.ssl.enabled true) }}
+{{- if .Values.ingress }}
+{{- if and .Values.ingress.enabled .Values.ingress.acme  }}
 {{- if not (eq .Values.environmentName "prod") }}
 apiVersion: cert-manager.io/v1alpha2
 kind: Issuer
@@ -10,7 +10,7 @@ spec:
    # The ACME server URL
    server: https://acme-staging-v02.api.letsencrypt.org/directory
    # Email address used for ACME registration
-   email: dev@high-mobility.com
+   email: {{ .Values.ingress.acmeRegistrationEamil }}
    # Name of a secret used to store the ACME account private key
    privateKeySecretRef:
      name: {{ include "hm-basic-webapp.letsEncryptStagingName" . }}

--- a/hm-basic-webapp/templates/secret_tls.yaml
+++ b/hm-basic-webapp/templates/secret_tls.yaml
@@ -1,7 +1,8 @@
-{{- if .Values.ssl }}
-{{- if (eq .Values.ssl.enabled true) }}
-{{- range $item := .Values.ssl }}
-{{- if and $item.crt $item.key $item.manual }}
+{{- if .Values.ingress }}
+{{- if (eq .Values.ingress.enabled true) }}
+{{- if (eq .Values.ingress.acme false) }}
+{{- range $item := .Values.ingress.tls }}
+{{- if and $item.crt $item.key }}
 ---
 apiVersion: v1
 kind: Secret
@@ -11,6 +12,7 @@ metadata:
 data:
   tls.crt: {{ $item.crt }}
   tls.key: {{ $item.key }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/hm-basic-webapp/values.yaml
+++ b/hm-basic-webapp/values.yaml
@@ -14,7 +14,6 @@ ingress:
   enabled: true
   acme: true
   acmeRegistrationEamil: nobody@localhost.local
-  host: dev.localhost.local
   path: /
   tlsSecretName: dev-localhost-local-tls
 migration:

--- a/hm-basic-webapp/values.yaml
+++ b/hm-basic-webapp/values.yaml
@@ -10,3 +10,16 @@ servicePort: 8080
 imagePullSecrets:
   - name: 'regcred'
 replicas: 1
+ingress:
+  enabled: true
+  acme: true
+  acmeRegistrationEamil: nobody@localhost.local
+  host: dev.localhost.local
+  path: /
+  tlsSecretName: dev-localhost-local-tls
+migration:
+     enabled: true
+     command:
+       - echo
+       - hello
+       - world


### PR DESCRIPTION
* Changed the key from ssl to ingress.
* Only accepts one hostname for ingress configurations
* Allows acme tls in any env
* Configure acme email registration address as part of the config
* Use latest ingress version

with this change, the config could be like:
```
ingress:
  enabled: true
  acme: true
  acmeRegistrationEamil: nobody@localhost.local
  path: /
  tlsSecretName: dev-localhost-local-tls
```