### PR TITLE
Fork telegraf chart

### DIFF
--- a/telegraf/.helmignore
+++ b/telegraf/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/telegraf/Chart.yaml
+++ b/telegraf/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: telegraf
+version: 1.8.4
+appVersion: 1.19.0
+deprecated: false
+description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.
+keywords:
+  - telegraf
+  - collector
+  - timeseries
+  - influxdata
+  - influxdb
+  - agent
+home: https://www.influxdata.com/time-series-platform/telegraf/
+sources:
+  - https://github.com/influxdata/helm-charts/tree/master/charts/telegraf
+  - https://github.com/influxdata/helm-charts/
+maintainers:
+  - name: rawkode
+    email: rawkode@influxdata.com
+  - name: gitirabassi
+    email: giacomo@influxdata.com
+icon: https://avatars0.githubusercontent.com/u/5713248?s=200&v=4

--- a/telegraf/LICENSE
+++ b/telegraf/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 InfluxData
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/telegraf/OWNERS
+++ b/telegraf/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+- rawkode
+- gitirabassi
+- naseemkullah
+reviewers:
+- rawkode
+- gitirabassi
+- naseemkullah

--- a/telegraf/README.md
+++ b/telegraf/README.md
@@ -1,0 +1,69 @@
+# Telegraf Helm chart
+
+> This chart is a hard fork of https://github.com/influxdata/helm-charts and release under the same LICENSE
+> Patch https://github.com/influxdata/helm-charts/pull/302/files has been applied to accept socket_listener option
+
+[Telegraf](https://github.com/influxdata/telegraf) is a plugin-driven server agent used for collecting and reporting metrics.
+
+The Telegraf Helm chart uses the [Helm](https://helm.sh) package manager to bootstrap a Telegraf (`telegraf`) deployment on a [Kubernetes](http://kubernetes.io) cluster.
+
+To see a list of available Telegraf plugins, see https://github.com/influxdata/telegraf/tree/master/plugins/.
+
+## Prerequisites
+
+- Helm v2 or later
+- Kubernetes 1.4+ with beta APIs enabled
+
+## Install the chart
+
+1. Add the InfluxData Helm repository:
+
+   ```bash
+   helm repo add influxdata https://helm.influxdata.com/
+   ```
+
+2. Run the following command, providing a name for your Telegraf release:
+
+   ```bash
+   helm upgrade --install my-release influxdata/telegraf
+   ```
+
+   > **Tip**: `--install` can be shortened to `-i`.
+
+   This command deploys Telegraf on the Kubernetes cluster using the default configuration. To find parameters you can configure during installation, see [Configure the chart](#configure-the-chart).
+
+  > **Tip**: To view all Helm chart releases, run `helm list`.
+
+## Uninstall the chart
+
+To uninstall the `my-release` deployment, use the following command:
+
+```bash
+helm uninstall my-release
+```
+
+This command removes all Kubernetes components associated with the chart and deletes the release.
+
+## Configure the chart
+
+Plugins are configured as arrays of key/value dictionaries. Find configurable parameters, their descriptions, and their default values stored in `values.yaml`.
+
+To configure the chart, do either of the following:
+
+- Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade --install`. For example:
+
+  ```bash
+  helm upgrade --install my-release \
+    --set persistence.enabled=true \
+      influxdata/telegraf
+  ```
+
+  This command enables persistence.
+
+- Provide a YAML file that specifies the parameter values while installing the chart. For example, use the following command:
+
+  ```bash
+  helm upgrade --install my-release -f values.yaml influxdata/telegraf
+  ```
+
+  > **Tip**: Use the default [values.yaml](values.yaml).

--- a/telegraf/templates/NOTES.txt
+++ b/telegraf/templates/NOTES.txt
@@ -1,0 +1,14 @@
+To open a shell session in the container running Telegraf run the following:
+
+  kubectl exec -i -t --namespace {{ .Release.Namespace }} $(kubectl get pods --namespace {{ .Release.Namespace }} -l app.kubernetes.io/name={{ include "telegraf.fullname" . }} -o jsonpath='{.items[0].metadata.name}') /bin/sh
+
+To view the logs for a Telegraf pod, run the following:
+
+  kubectl logs -f --namespace {{ .Release.Namespace }} $(kubectl get pods --namespace {{ .Release.Namespace }} -l app.kubernetes.io/name={{ include "telegraf.fullname" . }} -o jsonpath='{ .items[0].metadata.name }')
+
+{{- if eq .Values.service.type "LoadBalancer" }}
+
+To watch for the LoadBalancer IP run the following:
+
+  kubectl get svc -w --namespace {{ .Release.Namespace }} -l app.kubernetes.io/name={{ include "telegraf.fullname" . }}
+{{- end }}

--- a/telegraf/templates/_helpers.tpl
+++ b/telegraf/templates/_helpers.tpl
@@ -1,0 +1,527 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "telegraf.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "telegraf.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "telegraf.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "telegraf.labels" -}}
+helm.sh/chart: {{ include "telegraf.chart" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{ include "telegraf.selectorLabels" . }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "telegraf.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "telegraf.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+
+{{/*
+  CUSTOM TEMPLATES: This section contains templates that make up the different parts of the telegraf configuration file.
+  - global_tags section
+  - agent section
+*/}}
+
+{{- define "global_tags" -}}
+{{- if . -}}
+[global_tags]
+  {{- range $key, $val := . }}
+      {{ $key }} = {{ $val | quote }}
+  {{- end }}
+{{- end }}
+{{- end -}}
+
+{{- define "agent" -}}
+[agent]
+{{- range $key, $value := . -}}
+  {{- $tp := typeOf $value }}
+  {{- if eq $tp "string"}}
+      {{ $key }} = {{ $value | quote }}
+  {{- end }}
+  {{- if eq $tp "float64"}}
+      {{ $key }} = {{ $value | int64 }}
+  {{- end }}
+  {{- if eq $tp "int"}}
+      {{ $key }} = {{ $value | int64 }}
+  {{- end }}
+  {{- if eq $tp "bool"}}
+      {{ $key }} = {{ $value }}
+  {{- end }}
+{{- end }}
+{{- end -}}
+
+{{- define "outputs" -}}
+{{- range $outputIdx, $configObject := . -}}
+    {{- range $output, $config := . -}}
+
+    [[outputs.{{- $output }}]]
+    {{- if $config -}}
+    {{- $tp := typeOf $config -}}
+    {{- if eq $tp "map[string]interface {}" -}}
+        {{- range $key, $value := $config -}}
+          {{- $tp := typeOf $value -}}
+          {{- if eq $tp "string" }}
+      {{ $key }} = {{ $value | quote }}
+          {{- end }}
+          {{- if eq $tp "float64" }}
+      {{ $key }} = {{ $value | int64 }}
+          {{- end }}
+          {{- if eq $tp "int" }}
+      {{ $key }} = {{ $value | int64 }}
+          {{- end }}
+          {{- if eq $tp "bool" }}
+      {{ $key }} = {{ $value }}
+          {{- end }}
+          {{- if eq $tp "[]interface {}" }}
+      {{ $key }} = [
+              {{- $numOut := len $value }}
+              {{- $numOut := sub $numOut 1 }}
+              {{- range $b, $val := $value }}
+                {{- $i := int64 $b }}
+                {{- $tp := typeOf $val }}
+                {{- if eq $i $numOut }}
+                  {{- if eq $tp "string" }}
+        {{ $val | quote }}
+                  {{- end }}
+                  {{- if eq $tp "float64" }}
+        {{ $val | int64 }}
+                  {{- end }}
+                {{- else }}
+                  {{- if eq $tp "string" }}
+        {{ $val | quote }},
+                  {{- end}}
+                  {{- if eq $tp "float64" }}
+        {{ $val | int64 }},
+                  {{- end }}
+                {{- end }}
+              {{- end }}
+      ]
+          {{- end }}
+        {{- end }}
+        {{- range $key, $value := $config -}}
+          {{- $tp := typeOf $value -}}
+          {{- if eq $tp "map[string]interface {}" }}
+      [outputs.{{ $output }}.{{ $key }}]
+            {{- range $k, $v := $value }}
+              {{- $tps := typeOf $v }}
+              {{- if eq $tps "string" }}
+        {{ $k }} = {{ $v | quote }}
+              {{- end }}
+              {{- if eq $tps "float64" }}
+        {{ $k }} = {{ $v | int64 }}.0
+              {{- end }}
+              {{- if eq $tps "int64" }}
+        {{ $k }} = {{ $v | int64 }}
+              {{- end }}
+              {{- if eq $tps "bool" }}
+        {{ $k }} = {{ $v }}
+              {{- end }}
+              {{- if eq $tps "[]interface {}"}}
+        {{ $k }} = [
+                {{- $numOut := len $v }}
+                {{- $numOut := sub $numOut 1 }}
+                {{- range $b, $val := $v }}
+                  {{- $i := int64 $b }}
+                  {{- if eq $i $numOut }}
+            {{ $val | quote }}
+                  {{- else }}
+            {{ $val | quote }},
+                  {{- end }}
+                {{- end }}
+        ]
+              {{- end }}
+              {{- if eq $tps "map[string]interface {}"}}
+          [outputs.{{ $output }}.{{ $key }}.{{ $k }}]
+                {{- range $foo, $bar := $v }}
+            {{ $foo }} = {{ $bar | quote }}
+                {{- end }}
+              {{- end }}
+            {{- end }}
+          {{- end }}
+          {{- end }}
+    {{- end }}
+    {{- end }}
+    {{ end }}
+{{- end }}
+{{- end -}}
+
+{{- define "inputs" -}}
+{{- range $inputIdx, $configObject := . -}}
+    {{- range $input, $config := . -}}
+
+    [[inputs.{{- $input }}]]
+    {{- if $config -}}
+    {{- $tp := typeOf $config -}}
+    {{- if eq $tp "map[string]interface {}" -}}
+        {{- range $key, $value := $config -}}
+          {{- $tp := typeOf $value -}}
+          {{- if eq $tp "string" }}
+      {{ $key }} = {{ $value | quote }}
+          {{- end }}
+          {{- if eq $tp "float64" }}
+      {{ $key }} = {{ $value | int64 }}
+          {{- end }}
+          {{- if eq $tp "int" }}
+      {{ $key }} = {{ $value | int64 }}
+          {{- end }}
+          {{- if eq $tp "bool" }}
+      {{ $key }} = {{ $value }}
+          {{- end }}
+          {{- if eq $tp "[]interface {}" }}
+      {{ $key }} = [
+              {{- $numOut := len $value }}
+              {{- $numOut := sub $numOut 1 }}
+              {{- range $b, $val := $value }}
+                {{- $i := int64 $b }}
+                {{- $tp := typeOf $val }}
+                {{- if eq $i $numOut }}
+                  {{- if eq $tp "string" }}
+        {{ $val | quote }}
+                  {{- end }}
+                  {{- if eq $tp "float64" }}
+        {{ $val | int64 }}
+                  {{- end }}
+                {{- else }}
+                  {{- if eq $tp "string" }}
+        {{ $val | quote }},
+                  {{- end}}
+                  {{- if eq $tp "float64" }}
+        {{ $val | int64 }},
+                  {{- end }}
+                {{- end }}
+              {{- end }}
+      ]
+          {{- end }}
+          {{- end }}
+          {{- range $key, $value := $config -}}
+          {{- $tp := typeOf $value -}}
+          {{- if eq $tp "map[string]interface {}" }}
+      [inputs.{{ $input }}.{{ $key }}]
+            {{- range $k, $v := $value }}
+              {{- $tps := typeOf $v }}
+              {{- if eq $tps "string" }}
+        {{ $k }} = {{ $v | quote }}
+              {{- end }}
+              {{- if eq $tps "[]interface {}"}}
+        {{ $k }} = [
+                {{- $numOut := len $v }}
+                {{- $numOut := sub $numOut 1 }}
+                {{- range $b, $val := $v }}
+                  {{- $i := int64 $b }}
+                  {{- if eq $i $numOut }}
+            {{ $val | quote }}
+                  {{- else }}
+            {{ $val | quote }},
+                  {{- end }}
+                {{- end }}
+        ]
+              {{- end }}
+              {{- end }}
+              {{- range $k, $v := $value }}
+              {{- $tps := typeOf $v }}
+              {{- if eq $tps "map[string]interface {}"}}
+          [inputs.{{ $input }}.{{ $key }}.{{ $k }}]
+                {{- range $foo, $bar := $v }}
+            {{ $foo }} = {{ $bar | quote }}
+                {{- end }}
+              {{- end }}
+            {{- end }}
+          {{- end }}
+          {{- end }}
+    {{- end }}
+    {{- end }}
+    {{ end }}
+{{- end }}
+{{- end -}}
+
+{{- define "processors" -}}
+{{- range $processorIdx, $configObject := . -}}
+    {{- range $processor, $config := . -}}
+
+    [[processors.{{- $processor }}]]
+    {{- if $config -}}
+    {{- $tp := typeOf $config -}}
+    {{- if eq $tp "map[string]interface {}" -}}
+        {{- range $key, $value := $config -}}
+          {{- $tp := typeOf $value -}}
+          {{- if eq $tp "string" }}
+      {{ $key }} = {{ $value | quote }}
+          {{- end }}
+          {{- if eq $tp "float64" }}
+      {{ $key }} = {{ $value | int64 }}
+          {{- end }}
+          {{- if eq $tp "int" }}
+      {{ $key }} = {{ $value | int64 }}
+          {{- end }}
+          {{- if eq $tp "bool" }}
+      {{ $key }} = {{ $value }}
+          {{- end }}
+          {{- if eq $tp "[]interface {}" }}
+      {{ $key }} = [
+              {{- $numOut := len $value }}
+              {{- $numOut := sub $numOut 1 }}
+              {{- range $b, $val := $value }}
+                {{- $i := int64 $b }}
+                {{- $tp := typeOf $val }}
+                {{- if eq $i $numOut }}
+                  {{- if eq $tp "string" }}
+        {{ $val | quote }}
+                  {{- end }}
+                  {{- if eq $tp "float64" }}
+        {{ $val | int64 }}
+                  {{- end }}
+                {{- else }}
+                  {{- if eq $tp "string" }}
+        {{ $val | quote }},
+                  {{- end}}
+                  {{- if eq $tp "float64" }}
+        {{ $val | int64 }},
+                  {{- end }}
+                {{- end }}
+              {{- end }}
+      ]
+          {{- end }}
+          {{- end }}
+          {{- range $key, $value := $config -}}
+          {{- $tp := typeOf $value -}}
+          {{- if eq $tp "map[string]interface {}" }}
+      {{- if or (eq $processor "converter") (eq $processor "override") (eq $processor "clone") }}
+      [processors.{{ $processor }}.{{ $key }}]
+            {{- range $k, $v := $value }}
+              {{- $tps := typeOf $v }}
+              {{- if eq $tps "string" }}
+        {{ $k }} = {{ $v | quote }}
+              {{- end }}
+              {{- if eq $tps "[]interface {}"}}
+        {{ $k }} = [
+                {{- $numOut := len $v }}
+                {{- $numOut := sub $numOut 1 }}
+                {{- range $b, $val := $v }}
+                  {{- $i := int64 $b }}
+                  {{- if eq $i $numOut }}
+            {{ $val | quote }}
+                  {{- else }}
+            {{ $val | quote }},
+                  {{- end }}
+                {{- end }}
+        ]
+              {{- end }}
+              {{- end }}
+      {{- else }}
+       [[processors.{{ $processor }}.{{ $key }}]]
+            {{- range $k, $v := $value }}
+              {{- $tps := typeOf $v }}
+              {{- if eq $tps "string" }}
+        {{ $k }} = {{ $v | quote }}
+              {{- end }}
+              {{- if eq $tps "[]interface {}"}}
+        {{ $k }} = [
+                {{- $numOut := len $v }}
+                {{- $numOut := sub $numOut 1 }}
+                {{- range $b, $val := $v }}
+                  {{- $i := int64 $b }}
+                  {{- if eq $i $numOut }}
+            {{ $val | quote }}
+                  {{- else }}
+            {{ $val | quote }},
+                  {{- end }}
+                {{- end }}
+        ]
+              {{- end }}
+              {{- end }}
+              {{- range $k, $v := $value }}
+              {{- $tps := typeOf $v }}
+              {{- if eq $tps "map[string]interface {}"}}
+        [processors.{{ $processor }}.{{ $key }}.{{ $k }}]
+                {{- range $foo, $bar := $v }}
+                {{- $tp := typeOf $bar -}}
+                {{- if eq $tp "string" }}
+            {{ $foo }} = {{ $bar | quote }}
+                {{- end }}
+                {{- if eq $tp "int" }}
+            {{ $foo }} = {{ $bar }}
+                {{- end }}
+                {{- if eq $tp "float64" }}
+            {{ $foo }} = {{ int64 $bar }}
+                {{- end }}
+                {{- end }}
+              {{- end }}
+            {{- end }}
+          {{- end }}
+          {{- end }}
+      {{- end }}
+    {{- end }}
+    {{- end }}
+    {{ end }}
+{{- end }}
+{{- end -}}
+
+
+{{- define "aggregators" -}}
+{{- range $aggregatorIdx, $configObject := . -}}
+    {{- range $aggregator, $config := . -}}
+
+    [[aggregators.{{- $aggregator }}]]
+    {{- if $config -}}
+    {{- $tp := typeOf $config -}}
+    {{- if eq $tp "map[string]interface {}" -}}
+        {{- range $key, $value := $config -}}
+          {{- $tp := typeOf $value -}}
+          {{- if eq $tp "string" }}
+      {{ $key }} = {{ $value | quote }}
+          {{- end }}
+          {{- if eq $tp "float64" }}
+      {{ $key }} = {{ $value | int64 }}
+          {{- end }}
+          {{- if eq $tp "int" }}
+      {{ $key }} = {{ $value | int64 }}
+          {{- end }}
+          {{- if eq $tp "bool" }}
+      {{ $key }} = {{ $value }}
+          {{- end }}
+          {{- if eq $tp "[]interface {}" }}
+      {{ $key }} = [
+              {{- $numOut := len $value }}
+              {{- $numOut := sub $numOut 1 }}
+              {{- range $b, $val := $value }}
+                {{- $i := int64 $b }}
+                {{- $tp := typeOf $val }}
+                {{- if eq $i $numOut }}
+                  {{- if eq $tp "string" }}
+        {{ $val | quote }}
+                  {{- end }}
+                  {{- if eq $tp "float64" }}
+        {{ $val | int64 }}
+                  {{- end }}
+                {{- else }}
+                  {{- if eq $tp "string" }}
+        {{ $val | quote }},
+                  {{- end}}
+                  {{- if eq $tp "float64" }}
+        {{ $val | int64 }},
+                  {{- end }}
+                {{- end }}
+              {{- end }}
+      ]
+          {{- end }}
+          {{- end }}
+          {{- range $key, $value := $config -}}
+          {{- $tp := typeOf $value -}}
+          {{- if eq $tp "map[string]interface {}" }}
+      [[aggregators.{{ $aggregator }}.{{ $key }}]]
+            {{- range $k, $v := $value }}
+              {{- $tps := typeOf $v }}
+              {{- if eq $tps "string" }}
+        {{ $k }} = {{ $v | quote }}
+              {{- end }}
+              {{- if eq $tps "[]interface {}"}}
+        {{ $k }} = [
+                {{- $numOut := len $v }}
+                {{- $numOut := sub $numOut 1 }}
+                {{- range $b, $val := $v }}
+                  {{- $i := int64 $b }}
+                  {{- $tv := typeOf $val -}}
+                  {{- if eq $i $numOut }}
+                      {{- if eq $tv "string" }}
+                  {{ $val | quote }}
+                      {{- end }}
+                      {{- if eq $tv "float64" }}
+                        {{- $xval := float64 (int64 $val) -}}
+                        {{- if eq $val $xval -}}
+                  {{ $val | float64 }}.0
+                        {{- else -}}
+                  {{ $val | float64 }}
+                        {{- end -}}
+                      {{- end }}
+                      {{- if eq $tv "int64" }}
+                  {{ $val | int64 }}
+                      {{- end }}
+                  {{- else }}
+                      {{- if eq $tv "string" }}
+                  {{ $val | quote }},
+                      {{- end }}
+                      {{- if eq $tv "float64" }}
+                        {{- $xval := float64 (int64 $val) -}}
+                        {{- if eq $val $xval -}}
+                  {{ $val | float64 }}.0,
+                        {{- else -}}
+                  {{ $val | float64 }},
+                        {{- end -}}
+                      {{- end }}
+                      {{- if eq $tv "int64" }}
+                  {{ $val | int64 }},
+                      {{- end }}
+                  {{- end }}
+                {{- end }}
+        ]
+              {{- end }}
+              {{- end }}
+              {{- range $k, $v := $value }}
+              {{- $tps := typeOf $v }}
+              {{- if eq $tps "map[string]interface {}"}}
+        [aggregators.{{ $aggregator }}.{{ $key }}.{{ $k }}]
+                {{- range $foo, $bar := $v }}
+                {{- $tp := typeOf $bar -}}
+                {{- if eq $tp "string" }}
+            {{ $foo }} = {{ $bar | quote }}
+                {{- end }}
+                {{- if eq $tp "int" }}
+            {{ $foo }} = {{ $bar }}
+                {{- end }}
+                {{- if eq $tp "float64" }}
+            {{ $foo }} = {{ int64 $bar }}
+                {{- end }}
+                {{- end }}
+              {{- end }}
+            {{- end }}
+          {{- end }}
+          {{- end }}
+    {{- end }}
+    {{- end }}
+    {{ end }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "telegraf.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "telegraf.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/telegraf/templates/configmap.yaml
+++ b/telegraf/templates/configmap.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "telegraf.fullname" . }}
+  labels:
+    {{- include "telegraf.labels" . | nindent 4 }}
+data:
+  telegraf.conf: |+
+    {{ template "global_tags" .Values.config.global_tags }}
+    {{ template "agent" .Values.config.agent }}
+    {{ template "processors" .Values.config.processors }}
+    {{ template "aggregators" .Values.config.aggregators }}
+    {{ template "outputs" .Values.config.outputs }}
+    {{- if .Values.metrics.health.enabled }}
+    [[outputs.health]]
+      service_address = "http://:8888"
+      [[outputs.health.compares]]
+        field = "buffer_size"
+        lt = 5000.0
+      [[outputs.health.contains]]
+        field = "buffer_size"
+    {{- end }}
+    {{ template "inputs" .Values.config.inputs -}}
+    [[inputs.internal]]
+      collect_memstats = {{ .Values.metrics.collect_memstats }}

--- a/telegraf/templates/deployment.yaml
+++ b/telegraf/templates/deployment.yaml
@@ -1,0 +1,117 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "telegraf.fullname" . }}
+  labels:
+    {{- include "telegraf.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "telegraf.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "telegraf.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+{{- with .Values.podLabels }}
+{{ toYaml . | indent 8 }}
+{{- end }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
+        {{- end }}
+    spec:
+{{- if .Values.securityContext }}
+      securityContext:
+{{ toYaml .Values.securityContext | indent 8 }}
+{{- end }}
+      serviceAccountName: {{ template "telegraf.serviceAccountName" . }}
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repo }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ default "" .Values.image.pullPolicy | quote }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+        {{- if .Values.args }}
+        args:
+{{ toYaml .Values.args | indent 8 }}
+        {{- end }}
+        env:
+{{ toYaml .Values.env | indent 8 }}
+{{- if .Values.envFromSecret }}
+        envFrom:
+          - secretRef:
+              name: {{ .Values.envFromSecret }}
+{{- end }}
+        volumeMounts:
+        - name: config
+          mountPath: /etc/telegraf
+        {{- range .Values.volumeMounts }}
+        - name: {{ .name }}
+          mountPath: {{ .mountPath }}
+        {{- end }}
+        {{- if .Values.mountPoints }}
+{{ toYaml .Values.mountPoints | indent 8 }}
+        {{- end }}
+        {{- if .Values.hooks }}
+        {{- if or (.Values.hooks.postStart) (.Values.hooks.preStop) }}
+        lifecycle:
+        {{- if .Values.hooks.postStart }}
+          postStart:
+            exec:
+              command:
+        {{- range .Values.hooks.postStart }}
+                - {{ . | quote }}
+        {{- end }}
+        {{ end }}
+        {{- if .Values.hooks.preStop }}
+          preStop:
+            exec:
+              command:
+        {{- range .Values.hooks.preStop }}
+                - {{ . | quote }}
+        {{- end }}
+        {{ end }}
+        {{ end }}
+        {{ end }}
+        {{- range $objectKey, $objectValue := .Values.config.outputs }}
+        {{- range $key, $value := . -}}
+        {{- $tp := typeOf $value -}}
+        {{- if eq $key "health" }}
+        livenessProbe:
+          httpGet:
+            path: /
+            port: {{ trimPrefix "http://:" $value.service_address | int64 }}
+        readinessProbe:
+          httpGet:
+            path: /
+            port: {{ trimPrefix "http://:" $value.service_address | int64 }}
+        {{- end }}
+        {{- end }}
+        {{- end }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+      {{- end }}
+      volumes:
+      - name: config
+        configMap:
+          name: {{ include "telegraf.fullname" . }}
+      {{- if .Values.volumes }}
+{{ toYaml .Values.volumes | indent 6 }}
+      {{- end }}

--- a/telegraf/templates/pdb.yaml
+++ b/telegraf/templates/pdb.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.pdb.create }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "telegraf.fullname" . }}
+  labels:
+  {{- include "telegraf.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.pdb.minAvailable }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  {{- end }}
+  {{- if .Values.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+  {{- include "telegraf.selectorLabels" . | nindent 6 }}
+  {{- end }}

--- a/telegraf/templates/role.yaml
+++ b/telegraf/templates/role.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- if .Values.rbac.clusterWide }}
+kind: ClusterRole
+{{- else }}
+kind: Role
+{{- end }}
+metadata:
+  name: {{ template "telegraf.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "telegraf.labels" . | nindent 4 }}
+rules:
+{{ toYaml .Values.rbac.rules | indent 2 }}
+{{- end }}

--- a/telegraf/templates/rolebinding.yaml
+++ b/telegraf/templates/rolebinding.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- if .Values.rbac.clusterWide }}
+kind: ClusterRoleBinding
+{{- else }}
+kind: RoleBinding
+{{- end }}
+metadata:
+  name: {{ template "telegraf.fullname" . }}
+  labels:
+    {{- include "telegraf.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "telegraf.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  {{- if .Values.rbac.clusterWide }}
+  kind: ClusterRole
+  {{- else }}
+  kind: Role
+  {{- end }}
+  name: {{ template "telegraf.fullname" . }}
+{{- end }}

--- a/telegraf/templates/service.yaml
+++ b/telegraf/templates/service.yaml
@@ -1,0 +1,74 @@
+{{- if .Values.service.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "telegraf.fullname" . }}
+  labels:
+    {{- include "telegraf.labels" . | nindent 4 }}
+  {{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  {{- if .Values.metrics.health.enabled }}
+  - port: 8888
+    targetPort: 8888
+    name: "health"
+  {{- end }}
+  {{- range $objectKey, $objectValue := .Values.config.inputs }}
+  {{- range $key, $value := . -}}
+    {{- $tp := typeOf $value -}}
+    {{- if eq $key "http_listener" }}
+  - port: {{ trimPrefix ":" $value.service_address | int64 }}
+    targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
+    name: "http-listener"
+    {{- end }}
+    {{- if eq $key "influxdb_listener" }}
+  - port: {{ trimPrefix ":" $value.service_address | int64 }}
+    targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
+    name: "influxdb-listener"
+    {{- end }}
+    {{- if eq $key "http_listener_v2" }}
+  - port: {{ trimPrefix ":" $value.service_address | int64 }}
+    targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
+    name: "http-listener-v2"
+    {{- end }}
+    {{- if eq $key "statsd" }}
+  - port: {{ trimPrefix ":" $value.service_address | int64 }}
+    targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
+    protocol: "UDP"
+    name: "statsd"
+    {{- end }}
+    {{- if eq $key "tcp_listener" }}
+  - port: {{ trimPrefix ":" $value.service_address | int64 }}
+    targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
+    name: "tcp-listener"
+    {{- end }}
+    {{- if eq $key "udp_listener" }}
+  - port: {{ trimPrefix ":" $value.service_address | int64 }}
+    targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
+    protocol: "UDP"
+    name: "udp-listener"
+    {{- end }}
+    {{- if eq $key "webhooks" }}
+  - port: {{ trimPrefix ":" $value.service_address | int64 }}
+    targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
+    name: "webhooks"
+    {{- end }}
+  {{- end -}}
+  {{- end }}
+  {{- range $objectKey, $objectValue := .Values.config.outputs }}
+  {{- range $key, $value := . -}}
+    {{- $tp := typeOf $value -}}
+    {{- if eq $key "prometheus_client" }}
+  - port: {{ trimPrefix ":" $value.listen | int64 }}
+    targetPort: {{ trimPrefix ":" $value.listen | int64 }}
+    name: "prometheus-client"
+    {{- end }}
+  {{- end -}}
+  {{- end }}
+  selector:
+    {{- include "telegraf.selectorLabels" . | nindent 4 }}
+{{- end -}}

--- a/telegraf/templates/service.yaml
+++ b/telegraf/templates/service.yaml
@@ -57,6 +57,14 @@ spec:
     targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
     name: "webhooks"
     {{- end }}
+    {{- if eq $key "socket_listener" }}
+    {{- if or (hasPrefix "udp" $value.service_address) (hasPrefix "tcp" $value.service_address) }}
+  - port: {{ regexFind "[0-9]+$" $value.service_address  | int64 }}
+    targetPort: {{ regexFind "[0-9]+$" $value.service_address  | int64 }}
+    protocol: {{ upper (substr 0 3 $value.service_address) }}
+    name: {{ printf "%s-%s" "socket-listener" (regexFind "[0-9]+$" $value.service_address) }}
+    {{- end }}
+    {{- end }}
   {{- end -}}
   {{- end }}
   {{- range $objectKey, $objectValue := .Values.config.outputs }}

--- a/telegraf/templates/serviceaccount.yaml
+++ b/telegraf/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "telegraf.serviceAccountName" . }}
+  labels:
+    {{- include "telegraf.labels" . | nindent 4 }}
+  {{- if .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/telegraf/values.yaml
+++ b/telegraf/values.yaml
@@ -1,0 +1,187 @@
+## Default values.yaml for Telegraf
+## This is a YAML-formatted file.
+## ref: https://hub.docker.com/r/library/telegraf/tags/
+
+replicaCount: 1
+
+image:
+  repo: "telegraf"
+  tag: "1.19-alpine"
+  pullPolicy: IfNotPresent
+
+podAnnotations: {}
+
+podLabels: {}
+
+imagePullSecrets: []
+
+## Configure args passed to Telegraf containers
+args: []
+
+
+# The name of a secret in the same kubernetes namespace which contains values to
+# be added to the environment (must be manually created)
+# This can be useful for auth tokens, etc.
+
+# envFromSecret: "telegraf-tokens"
+
+
+env:
+  - name: HOSTNAME
+    value: "telegraf-polling-service"
+
+# An older "volumeMounts" key was previously added which will likely
+# NOT WORK as you expect. Please use this newer configuration.
+
+# volumes:
+# - name: telegraf-output-influxdb2
+#   configMap:
+#     name: "telegraf-output-influxdb2"
+# mountPoints:
+# - name: telegraf-output-influxdb2
+#   mountPath: /etc/telegraf/conf.d
+#   subPath: influxdb2.conf
+
+
+## Configure resource requests and limits
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+resources: {}
+  # requests:
+  #   memory: 128Mi
+  #   cpu: 100m
+  # limits:
+  #   memory: 128Mi
+  #   cpu: 100m
+
+## Node labels for pod assignment
+## ref: https://kubernetes.io/docs/user-guide/node-selection/
+nodeSelector: {}
+
+## Affinity for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+##
+affinity: {}
+
+## Tolerations for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+##
+tolerations: []
+# - key: "key"
+#   operator: "Equal|Exists"
+#   value: "value"
+#   effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
+
+service:
+  enabled: true
+  type: ClusterIP
+  annotations: {}
+
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: true
+  # Create only for the release namespace or cluster wide (Role vs ClusterRole)
+  clusterWide: false
+  # Rules for the created rule
+  rules: []
+# When using the prometheus input to scrape all pods you need extra rules set to the ClusterRole to be
+# able to scan the pods for scraping labels. The following rules have been taken from:
+# https://github.com/helm/charts/blob/master/stable/prometheus/templates/server-clusterrole.yaml#L8-L46
+#    - apiGroups:
+#        - ""
+#      resources:
+#        - nodes
+#        - nodes/proxy
+#        - nodes/metrics
+#        - services
+#        - endpoints
+#        - pods
+#        - ingresses
+#        - configmaps
+#      verbs:
+#        - get
+#        - list
+#        - watch
+#    - apiGroups:
+#        - "extensions"
+#      resources:
+#        - ingresses/status
+#        - ingresses
+#      verbs:
+#        - get
+#        - list
+#        - watch
+#    - nonResourceURLs:
+#        - "/metrics"
+#      verbs:
+#        - get
+
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+  # Annotations for the ServiceAccount
+  annotations: {}
+
+## Exposed telegraf configuration
+## For full list of possible values see `/docs/all-config-values.yaml` and `/docs/all-config-values.toml`
+## ref: https://docs.influxdata.com/telegraf/v1.1/administration/configuration/
+config:
+  agent:
+    interval: "10s"
+    round_interval: true
+    metric_batch_size: 1000
+    metric_buffer_limit: 10000
+    collection_jitter: "0s"
+    flush_interval: "10s"
+    flush_jitter: "0s"
+    precision: ""
+    debug: false
+    quiet: false
+    logfile: ""
+    hostname: "$HOSTNAME"
+    omit_hostname: false
+  processors:
+    - enum:
+        mapping:
+          field: "status"
+          dest: "status_code"
+          value_mappings:
+            healthy: 1
+            problem: 2
+            critical: 3
+  outputs:
+    - influxdb:
+        urls:
+          - "http://influxdb.monitoring.svc:8086"
+        database: "telegraf"
+  inputs:
+    - statsd:
+        service_address: ":8125"
+        percentiles:
+          - 50
+          - 95
+          - 99
+        metric_separator: "_"
+        allowed_pending_messages: 10000
+        percentile_limit: 1000
+
+metrics:
+  health:
+    enabled: false
+  collect_memstats: false
+
+# Lifecycle hooks
+# hooks:
+#   postStart: ["/bin/sh", "-c", "echo Telegraf started"]
+#   preStop: ["/bin/sh", "-c", "sleep 60"]
+
+## Pod disruption budget configuration
+##
+pdb:
+  ## Specifies whether a Pod disruption budget should be created
+  ##
+  create: true
+  minAvailable: 1
+  # maxUnavailable: 1


### PR DESCRIPTION
Due to the lack of response from https://github.com/influxdata/helm-charts/pull/302 I'd suggest to fork the chart.

The down side is we have to keep the chart up-to-date. Since the services of telegraf are not exposed to outside cluster, we shouldn't have problem with running old versions.


I've added a note in the `README.md` and also copied the LICENCE file from the main repo to this directory.