### PR TITLE
Deployment strategy option for hm-worker chart 

### DIFF
--- a/hm-worker/CHANGELOG.md
+++ b/hm-worker/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## [1.1.0] - 2022-05-04
+### Add
+
+* Option to configure [deployment strategy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy). Default set to `RollingUpdate`
+
+
+## [1.0.0] - 2022-02-06
+### Add
+
+* First release

--- a/hm-worker/Chart.yaml
+++ b/hm-worker/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/hm-worker/templates/deployment.yaml
+++ b/hm-worker/templates/deployment.yaml
@@ -8,6 +8,8 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  strategy:
+     type: "{{ .Values.deploymentStrategy }}"
   selector:
     matchLabels:
       {{- include "hm-worker.selectorLabels" . | nindent 6 }}

--- a/hm-worker/values.yaml
+++ b/hm-worker/values.yaml
@@ -14,6 +14,8 @@ ci:
   deploymentTag: dev
 
 
+deploymentStrategy: RollingUpdate
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""

--- a/index.yaml
+++ b/index.yaml
@@ -134,6 +134,16 @@ entries:
   hm-worker:
   - apiVersion: v2
     appVersion: 1.16.0
+    created: "2022-05-04T13:40:41.58705+02:00"
+    description: A Helm chart for running worker jobs without any HTTP service
+    digest: 22124d63aea3996d9533cdbc0e76f2355055374af37fc20fee7b22416896e242
+    name: hm-worker
+    type: application
+    urls:
+    - https://highmobility.github.io/helm-charts/hm-worker-1.1.0.tgz
+    version: 1.1.0
+  - apiVersion: v2
+    appVersion: 1.16.0
     created: "2022-03-03T18:42:07.56504+01:00"
     description: A Helm chart for running worker jobs without any HTTP service
     digest: b204a4fbb4aa6df2d8abd9243fd01c0d82fcc10572d610b4215fb62513d8031d
@@ -162,4 +172,4 @@ entries:
     urls:
     - https://highmobility.github.io/helm-charts/hm-worker-0.1.0.tgz
     version: 0.1.0
-generated: "2022-04-20T12:39:26.191292+03:00"
+generated: "2022-05-04T13:40:41.570843+02:00"


### PR DESCRIPTION
allows the user of this chart to set deployment strategy. `Recreate` is useful for workers which connect to Kafka since it avoid unnecessary consumer balancing during deployment.

kudos to @doofyus for #23 🎉 